### PR TITLE
backend/feat generate schedules and create API authorizer

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -86,4 +86,32 @@ jobs:
       - name: Run tests
         run: npm test
         working-directory: backend
-# TODO: Deploy in some service
+
+  deploy:
+    needs: [build, lint, test]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4 # Clones the repository with just latest commit
+        with:
+          fetch-depth: 0
+      
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      
+      - name: Install AWS SAM CLI
+        run: |
+          sudo apt update
+          sudo apt install -y awscli
+          pip install aws-sam-cli
+
+      - name: Make deploy script executable
+        run: chmod +x backend/deploy.sh
+
+      - name: Run Deploy Script
+        run: backend/deploy.sh
+

--- a/backend/__tests__/schemas/course.schema.test.ts
+++ b/backend/__tests__/schemas/course.schema.test.ts
@@ -4,7 +4,7 @@ describe('Course Schema Validation', () => {
   it('should validate a correct course', () => {
     const result = courseSchema.safeParse({
       courseName: 'Mathematics 101',
-      day: 'Lunes',
+      day: 'L',
       startTime: '08:00:00',
       endTime: '10:00:00',
       groupNumber: 1,
@@ -20,7 +20,7 @@ describe('Course Schema Validation', () => {
 
   it('should fail if courseName is missing', () => {
     const result = courseSchema.safeParse({
-      day: 'Martes',
+      day: 'K',
       startTime: '09:00:00',
       endTime: '11:00:00',
       groupNumber: 2
@@ -34,7 +34,7 @@ describe('Course Schema Validation', () => {
   it('should fail if day is invalid', () => {
     const result = courseSchema.safeParse({
       courseName: 'Physics 101',
-      day: 'Lundi',
+      day: 'Q',
       startTime: '10:00:00',
       endTime: '12:00:00',
       groupNumber: 3
@@ -42,7 +42,7 @@ describe('Course Schema Validation', () => {
     expect(result.success).toBe(false)
     if (!result.success) {
       expect(result.error.format().day?._errors).toContain(
-        "Invalid enum value. Expected 'Lunes' | 'Martes' | 'Miércoles' | 'Jueves' | 'Viernes' | 'Sábado' | 'Domingo', received 'Lundi'"
+        "Invalid enum value. Expected 'L' | 'K' | 'M' | 'J' | 'V' | 'S' | 'D', received 'Q'"
       )
     }
   })
@@ -50,7 +50,7 @@ describe('Course Schema Validation', () => {
   it('should fail if startTime is in the wrong format', () => {
     const result = courseSchema.safeParse({
       courseName: 'History 101',
-      day: 'Miércoles',
+      day: 'M',
       startTime: '10:00',
       endTime: '12:00:00',
       groupNumber: 1
@@ -66,7 +66,7 @@ describe('Course Schema Validation', () => {
   it('should fail if groupNumber is less than 1', () => {
     const result = courseSchema.safeParse({
       courseName: 'Biology 101',
-      day: 'Jueves',
+      day: 'J',
       startTime: '11:00:00',
       endTime: '13:00:00',
       groupNumber: 0
@@ -84,9 +84,9 @@ describe('Course Params Schema Validation', () => {
   it('should validate correct course params', () => {
     const result = courseParamsSchema.safeParse({
       courseName: 'Physics 101',
-      day: 'Viernes',
+      day: 'V',
       startTime: '14:00:00',
-      groupNumber: '2'
+      groupNumber: 2
     })
     expect(result.success).toBe(true)
   })
@@ -94,7 +94,7 @@ describe('Course Params Schema Validation', () => {
   it('should fail if courseName is empty', () => {
     const result = courseParamsSchema.safeParse({
       courseName: '',
-      day: 'Sábado',
+      day: 'S',
       startTime: '15:00:00',
       groupNumber: 3
     })

--- a/backend/__tests__/schemas/schedule.schema.test.ts
+++ b/backend/__tests__/schemas/schedule.schema.test.ts
@@ -1,0 +1,179 @@
+import { timeSlotSchema, scheduleSchema, groupSchema, courseSchema, generateScheduleSchema, allCoursesSchema } from '../../src/schemas/schedule.schema'
+
+/* eslint-disable @typescript-eslint/naming-convention */
+describe('Time Slot Schema Validation', () => {
+  it('should validate a correct time slot', () => {
+    const result = timeSlotSchema.safeParse({
+      start: '08:30',
+      end: '10:00'
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should fail if start time is in incorrect format', () => {
+    const result = timeSlotSchema.safeParse({
+      start: '8:30',
+      end: '10:00'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.format().start?._errors).toContain('Start time must be in HH:mm format')
+    }
+  })
+
+  it('should fail if end time is in incorrect format', () => {
+    const result = timeSlotSchema.safeParse({
+      start: '08:30',
+      end: '25:00'
+    })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.format().end?._errors).toContain('End time must be in HH:mm format')
+    }
+  })
+})
+
+describe('Schedule Schema Validation', () => {
+  it('should validate a correct schedule', () => {
+    const result = scheduleSchema.safeParse({
+      L: { start: '08:00', end: '10:00' },
+      M: { start: '14:00', end: '16:00' }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should fail if a day key is longer than one character', () => {
+    const result = scheduleSchema.safeParse({
+      Monday: { start: '08:00', end: '10:00' }
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should fail if a time slot is invalid', () => {
+    const result = scheduleSchema.safeParse({
+      L: { start: '08:60', end: '10:00' }
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('Group Schema Validation', () => {
+  it('should validate a correct group', () => {
+    const result = groupSchema.safeParse({
+      name: 'Group A',
+      schedule: {
+        L: { start: '09:00', end: '11:00' }
+      }
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should fail if group name is empty', () => {
+    const result = groupSchema.safeParse({
+      name: '',
+      schedule: {
+        L: { start: '09:00', end: '11:00' }
+      }
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should fail if schedule is empty', () => {
+    const result = groupSchema.safeParse({
+      name: 'Group B',
+      schedule: {}
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('Course Schema Validation', () => {
+  it('should validate a correct course', () => {
+    const result = courseSchema.safeParse({
+      name: 'Mathematics 101',
+      color: 'bg-red-500',
+      groups: [
+        {
+          name: 'Group A',
+          schedule: { L: { start: '08:00', end: '10:00' } }
+        }
+      ]
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('should fail if course name is empty', () => {
+    const result = courseSchema.safeParse({
+      name: '',
+      color: 'bg-red-500',
+      groups: [
+        {
+          name: 'Group A',
+          schedule: { L: { start: '08:00', end: '10:00' } }
+        }
+      ]
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('should fail if no groups are provided', () => {
+    const result = courseSchema.safeParse({
+      name: 'Physics 101',
+      color: 'bg-red-500',
+      groups: []
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('Generate Schedule Schema Validation', () => {
+  it('should validate a correct schedule generation', () => {
+    const result = generateScheduleSchema.safeParse([
+      {
+        name: 'Mathematics 101',
+        color: 'bg-red-500',
+        groups: [
+          {
+            name: 'Group A',
+            schedule: { M: { start: '09:00', end: '11:00' } }
+          }
+        ]
+      }
+    ])
+    expect(result.success).toBe(true)
+  })
+
+  it('should fail if no courses are provided', () => {
+    const result = generateScheduleSchema.safeParse([])
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('All Courses Schema Validation', () => {
+  it('should validate correct course data', () => {
+    const result = allCoursesSchema.safeParse([
+      {
+        courseName: 'Computer Science 101',
+        color: '#123456',
+        group: {
+          name: 'Group C',
+          schedule: { V: { start: '14:00', end: '16:00' } }
+        }
+      }
+    ])
+    expect(result.success).toBe(true)
+  })
+
+  it('should fail if color is missing', () => {
+    const result = allCoursesSchema.safeParse([
+      {
+        courseName: 'Chemistry 101',
+        group: {
+          name: 'Group D',
+          schedule: { S: { start: '12:00', end: '14:00' } }
+        }
+      }
+    ])
+    expect(result.success).toBe(false)
+  })
+})

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -18,9 +18,6 @@ echo "----------------------------------------"
 
 sam build
 
-echo "----------------------------------------"
-echo "Fetching secrets from AWS SSM Parameter Store..."
-echo "----------------------------------------"
 DB_HOST=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_HOST" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
 DB_USER=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_USER" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
 DB_PASSWORD=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_PASSWORD" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
@@ -28,10 +25,6 @@ DB_NAME=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_NAME" --with-decryp
 DB_PORT=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_PORT" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
 NODE_ENV=$(aws ssm get-parameter --name "/horariu/${STAGE}/NODE_ENV" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
 JWT_SECRET=$(aws ssm get-parameter --name "/horariu/${STAGE}/JWT_SECRET" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
-
-echo "----------------------------------------"
-echo "Secrets fetched successfully!"
-echo "----------------------------------------"
 
 echo "----------------------------------------"
 echo "Deploying to AWS Lambda..."
@@ -42,7 +35,6 @@ sam deploy \
   --s3-bucket $S3_BUCKET \
   --region $AWS_REGION \
   --capabilities CAPABILITY_IAM \
-  --confirm-changeset \
   --parameter-overrides \
   ParameterKey=StageName,ParameterValue=$STAGE \
   ParameterKey=DBHost,ParameterValue=$DB_HOST \
@@ -51,7 +43,8 @@ sam deploy \
   ParameterKey=DBName,ParameterValue=$DB_NAME \
   ParameterKey=DBPort,ParameterValue=$DB_PORT \
   ParameterKey=NodeEnv,ParameterValue=$NODE_ENV \
-  ParameterKey=JwtSecret,ParameterValue=$JWT_SECRET
+  ParameterKey=JwtSecret,ParameterValue=$JWT_SECRET \
+  | grep -v -E 'DBPassword|JwtSecret|DBUser|DBHost|DBName|DBPort|NodeEnv'
 
 echo "----------------------------------------"
 echo "All finished. Check if there's any errors or everything went smoothly!"

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -1,27 +1,33 @@
 #!/bin/bash
-# DO NOT hardcode secrets in this file.
-# Secrets are fetched securely from AWS SSM.
 
-# Set AWS region (customize if needed)
 AWS_REGION="us-east-1"
+S3_BUCKET="horariu-app-deployment-bucket"
+STAGE=${1:-Dev}  # Dev by default, but we can use Prod with the command: ./deploy.sh Prod
+
+STACK_NAME="horariu-${STAGE}"
 
 echo "Building the Lambda function with SAM..."
 sam build
 
 echo "Fetching secrets from AWS SSM Parameter Store..."
-DB_HOST=$(aws ssm get-parameter --name "/horariu/DB_HOST" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
-DB_USER=$(aws ssm get-parameter --name "/horariu/DB_USER" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
-DB_PASSWORD=$(aws ssm get-parameter --name "/horariu/DB_PASSWORD" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
-DB_NAME=$(aws ssm get-parameter --name "/horariu/DB_NAME" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
-DB_PORT=$(aws ssm get-parameter --name "/horariu/DB_PORT" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
-NODE_ENV=$(aws ssm get-parameter --name "/horariu/NODE_ENV" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
-JWT_SECRET=$(aws ssm get-parameter --name "/horariu/JWT_SECRET" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
+DB_HOST=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_HOST" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
+DB_USER=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_USER" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
+DB_PASSWORD=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_PASSWORD" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
+DB_NAME=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_NAME" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
+DB_PORT=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_PORT" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
+NODE_ENV=$(aws ssm get-parameter --name "/horariu/${STAGE}/NODE_ENV" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
+JWT_SECRET=$(aws ssm get-parameter --name "/horariu/${STAGE}/JWT_SECRET" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
 
 echo "Secrets fetched successfully!"
 
 echo "Deploying to AWS Lambda..."
 sam deploy \
+  --stack-name $STACK_NAME \
+  --s3-bucket $S3_BUCKET \
+  --region $AWS_REGION \
+  --capabilities CAPABILITY_IAM \
   --parameter-overrides \
+  ParameterKey=StageName,ParameterValue=$STAGE \
   ParameterKey=DBHost,ParameterValue=$DB_HOST \
   ParameterKey=DBUser,ParameterValue=$DB_USER \
   ParameterKey=DBPassword,ParameterValue=$DB_PASSWORD \

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -7,6 +7,12 @@ STAGE=${1:-Dev}  # Dev by default, but we can use Prod with the command: ./deplo
 STACK_NAME="horariu-${STAGE}"
 
 echo "----------------------------------------"
+echo "Building the project..."
+echo "----------------------------------------"
+
+npm run build
+
+echo "----------------------------------------"
 echo "Building the Lambda function with SAM..."
 echo "----------------------------------------"
 

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -6,10 +6,15 @@ STAGE=${1:-Dev}  # Dev by default, but we can use Prod with the command: ./deplo
 
 STACK_NAME="horariu-${STAGE}"
 
+echo "----------------------------------------"
 echo "Building the Lambda function with SAM..."
+echo "----------------------------------------"
+
 sam build
 
+echo "----------------------------------------"
 echo "Fetching secrets from AWS SSM Parameter Store..."
+echo "----------------------------------------"
 DB_HOST=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_HOST" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
 DB_USER=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_USER" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
 DB_PASSWORD=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_PASSWORD" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
@@ -18,14 +23,20 @@ DB_PORT=$(aws ssm get-parameter --name "/horariu/${STAGE}/DB_PORT" --with-decryp
 NODE_ENV=$(aws ssm get-parameter --name "/horariu/${STAGE}/NODE_ENV" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
 JWT_SECRET=$(aws ssm get-parameter --name "/horariu/${STAGE}/JWT_SECRET" --with-decryption --region $AWS_REGION --query "Parameter.Value" --output text)
 
+echo "----------------------------------------"
 echo "Secrets fetched successfully!"
+echo "----------------------------------------"
 
+echo "----------------------------------------"
 echo "Deploying to AWS Lambda..."
+echo "----------------------------------------"
+
 sam deploy \
   --stack-name $STACK_NAME \
   --s3-bucket $S3_BUCKET \
   --region $AWS_REGION \
   --capabilities CAPABILITY_IAM \
+  --confirm-changeset \
   --parameter-overrides \
   ParameterKey=StageName,ParameterValue=$STAGE \
   ParameterKey=DBHost,ParameterValue=$DB_HOST \
@@ -35,3 +46,7 @@ sam deploy \
   ParameterKey=DBPort,ParameterValue=$DB_PORT \
   ParameterKey=NodeEnv,ParameterValue=$NODE_ENV \
   ParameterKey=JwtSecret,ParameterValue=$JWT_SECRET
+
+echo "----------------------------------------"
+echo "All finished. Check if there's any errors or everything went smoothly!"
+echo "----------------------------------------"

--- a/backend/events/event-delete-course.json
+++ b/backend/events/event-delete-course.json
@@ -2,7 +2,7 @@
   "httpMethod": "DELETE",
   "path": "/courses/Programación%20II/L/09:00:00/2",
   "headers": {
-    "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJiYTU0YzRiMS05MzMxLTQ5Y2QtYTE5MC05OGIxNDliYWQ5NTIiLCJlbWFpbCI6InRlc3QxQGV4YW1wbGUuY29tIiwiaWF0IjoxNzQxNzI1NzQyLCJleHAiOjE3NDE3MjkzNDJ9.utjJsfdfsIV6Vy4SJ4BZAwmdtfyy8DE5BBv2GH67X8E"
+    "Authorization": "Bearer x"
   },
   "pathParameters": {
     "courseName": "Programación II",

--- a/backend/events/event-delete-course.json
+++ b/backend/events/event-delete-course.json
@@ -1,13 +1,18 @@
 {
   "httpMethod": "DELETE",
-  "path": "/courses/Programación%20Avanzada/Lunes/07:00:00/999",
+  "path": "/courses/Programación%20II/L/09:00:00/2",
   "headers": {
-    "Authorization": "Bearer xxxxx"
+    "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOiJiYTU0YzRiMS05MzMxLTQ5Y2QtYTE5MC05OGIxNDliYWQ5NTIiLCJlbWFpbCI6InRlc3QxQGV4YW1wbGUuY29tIiwiaWF0IjoxNzQxNzI1NzQyLCJleHAiOjE3NDE3MjkzNDJ9.utjJsfdfsIV6Vy4SJ4BZAwmdtfyy8DE5BBv2GH67X8E"
   },
   "pathParameters": {
-    "courseName": "Programación Avanzada",
-    "day": "Lunes",
-    "startTime": "07:00:00",
-    "groupNumber": "999"
+    "courseName": "Programación II",
+    "day": "L",
+    "startTime": "09:00:00",
+    "groupNumber": "2"
+  },
+  "requestContext": {
+    "authorizer": {
+      "principalId": "ba54c4b1-9331-49cd-a190-98b149bad952"
+    }
   }
 }

--- a/backend/events/event-generate-schedules.json
+++ b/backend/events/event-generate-schedules.json
@@ -1,0 +1,8 @@
+{
+  "httpMethod": "POST",
+  "path": "/courses/generate",
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": "[{\"name\":\"Bases de Datos Avanzadas\",\"color\":\"bg-red-500\",\"groups\":[{\"name\":\"01\",\"schedule\":{\"K\":{\"start\":\"10:00\",\"end\":\"11:50\"},\"V\":{\"start\":\"09:00\",\"end\":\"11:50\"}}},{\"name\":\"02\",\"schedule\":{\"L\":{\"start\":\"18:00\",\"end\":\"20:50\"},\"J\":{\"start\":\"18:00\",\"end\":\"19:50\"}}}]},{\"name\":\"Calidad de Software\",\"color\":\"bg-cyan-500\",\"groups\":[{\"name\":\"01\",\"schedule\":{\"L\":{\"start\":\"16:00\",\"end\":\"17:50\"},\"J\":{\"start\":\"15:00\",\"end\":\"17:50\"}}},{\"name\":\"02\",\"schedule\":{\"L\":{\"start\":\"13:00\",\"end\":\"15:50\"},\"J\":{\"start\":\"13:00\",\"end\":\"14:50\"}}}]}]"
+}

--- a/backend/events/event-get-course.json
+++ b/backend/events/event-get-course.json
@@ -1,13 +1,18 @@
 {
   "httpMethod": "GET",
-  "path": "/courses/Programación%20Avanzada/Lunes/07:00:00/1",
+  "path": "/courses/Programación%20Avanzada/L/07:00:00/1",
   "headers": {
     "Authorization": "Bearer x"
   },
   "pathParameters": {
     "courseName": "Programación Avanzada",
-    "day": "Lunes",
+    "day": "L",
     "startTime": "07:00:00",
     "groupNumber": "1"
+  },
+  "requestContext": {
+    "authorizer": {
+      "principalId": "ba54c4b1-9331-49cd-a190-98b149bad952"
+    }
   }
 }

--- a/backend/events/event-get-courses.json
+++ b/backend/events/event-get-courses.json
@@ -2,6 +2,11 @@
   "httpMethod": "GET",
   "path": "/courses",
   "headers": {
-    "Authorization": "Bearer xx.xx.xx"
+    "Authorization": "Bearer x"
+  },
+  "requestContext": {
+    "authorizer": {
+      "principalId": "ba54c4b1-9331-49cd-a190-98b149bad952"
+    }
   }
 }

--- a/backend/events/event-register-course.json
+++ b/backend/events/event-register-course.json
@@ -2,7 +2,12 @@
   "httpMethod": "POST",
   "path": "/courses",
   "headers": {
-    "Authorization": "Bearer xx.xx.xx"
+    "Authorization": "Bearer x"
   },
-  "body": "{ \"courseName\": \"Programación I\", \"day\": \"Lunes\", \"startTime\": \"09:00:00\", \"endTime\": \"11:50:00\", \"groupNumber\": 2, \"courseDetails\": { \"professor\": \"Dr. Juan Pérez\", \"courseCode\": \"CS101\", \"classroom\": \"Aula 305\" } }"
+  "body": "{ \"courseName\": \"Programación II\", \"day\": \"L\", \"startTime\": \"09:00:00\", \"endTime\": \"11:50:00\", \"groupNumber\": 2, \"courseDetails\": { \"professor\": \"Dr. Juan Pérez\", \"courseCode\": \"CS101\", \"classroom\": \"Aula 305\" } }",
+  "requestContext": {
+    "authorizer": {
+      "principalId": "ba54c4b1-9331-49cd-a190-98b149bad952"
+    }
+  }
 }

--- a/backend/events/event-update-course.json
+++ b/backend/events/event-update-course.json
@@ -1,14 +1,19 @@
 {
   "httpMethod": "PATCH",
-  "path": "/courses/Programación%20Avanzada/Lunes/07:00:00/1",
+  "path": "/courses/Programación%20Avanzada/L/07:00:00/1",
   "headers": {
     "Authorization": "Bearer xxxx"
   },
   "pathParameters": {
     "courseName": "Programación Avanzada",
-    "day": "Lunes",
+    "day": "L",
     "startTime": "07:00:00",
     "groupNumber": "1"
+  },
+  "requestContext": {
+    "authorizer": {
+      "principalId": "ba54c4b1-9331-49cd-a190-98b149bad952"
+    }
   },
   "body": "{ \"groupNumber\": 999, \"courseDetails\": { \"professor\": \"Dr. Pedrito Gonzalez\", \"courseCode\": \"9999\", \"classroom\": \"Aula 300\" } }"
 }

--- a/backend/events/event-update-course.json
+++ b/backend/events/event-update-course.json
@@ -2,7 +2,7 @@
   "httpMethod": "PATCH",
   "path": "/courses/Programación%20Avanzada/L/07:00:00/1",
   "headers": {
-    "Authorization": "Bearer xxxx"
+    "Authorization": "Bearer x"
   },
   "pathParameters": {
     "courseName": "Programación Avanzada",

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "migrate:studio": "npx drizzle-kit studio --config=src/drizzle.config.ts",
     "sam:invoke:register": "infisical run -- sam local invoke HorariuApiFunction -e events/event-register.json",
     "sam:invoke:login": "infisical run -- sam local invoke HorariuApiFunction -e events/event-login.json",
+    "sam:invoke:generateSchedules": "infisical run -- sam local invoke HorariuApiFunction -e events/event-generate-schedules.json",
     "sam:invoke:registerCourse": "infisical run -- sam local invoke HorariuApiFunction -e events/event-register-course.json",
     "sam:invoke:getCourses": "infisical run -- sam local invoke HorariuApiFunction -e events/event-get-courses.json",
     "sam:invoke:getCourse": "infisical run -- sam local invoke HorariuApiFunction -e events/event-get-course.json",
@@ -25,6 +26,7 @@
 
     "sam:invoke:register:debug": "infisical run -- sam local invoke --debug-port 5858 HorariuApiFunction -e events/event-register.json",
     "sam:invoke:login:debug": "infisical run -- sam local invoke --debug-port 5858 HorariuApiFunction -e events/event-login.json",
+    "sam:invoke:generateSchedules:debug": "infisical run -- sam local invoke HorariuApiFunction --debug-port 5858 -e events/event-generate-schedules.json",
     "sam:invoke:registerCourse:debug": "infisical run -- sam local invoke --debug-port 5858 HorariuApiFunction -e events/event-register-course.json",
     "sam:invoke:getCourses:debug": "infisical run -- sam local invoke --debug-port 5858 HorariuApiFunction -e events/event-get-courses.json",
     "sam:invoke:getCourse:debug": "infisical run -- sam local invoke --debug-port 5858 HorariuApiFunction -e events/event-get-course.json",

--- a/backend/package.json
+++ b/backend/package.json
@@ -21,7 +21,15 @@
     "sam:invoke:getCourses": "infisical run -- sam local invoke HorariuApiFunction -e events/event-get-courses.json",
     "sam:invoke:getCourse": "infisical run -- sam local invoke HorariuApiFunction -e events/event-get-course.json",
     "sam:invoke:updateCourse": "infisical run -- sam local invoke HorariuApiFunction -e events/event-update-course.json",
-    "sam:invoke:deleteCourse": "infisical run -- sam local invoke HorariuApiFunction -e events/event-delete-course.json"
+    "sam:invoke:deleteCourse": "infisical run -- sam local invoke HorariuApiFunction -e events/event-delete-course.json",
+
+    "sam:invoke:register:debug": "infisical run -- sam local invoke --debug-port 5858 HorariuApiFunction -e events/event-register.json",
+    "sam:invoke:login:debug": "infisical run -- sam local invoke --debug-port 5858 HorariuApiFunction -e events/event-login.json",
+    "sam:invoke:registerCourse:debug": "infisical run -- sam local invoke --debug-port 5858 HorariuApiFunction -e events/event-register-course.json",
+    "sam:invoke:getCourses:debug": "infisical run -- sam local invoke --debug-port 5858 HorariuApiFunction -e events/event-get-courses.json",
+    "sam:invoke:getCourse:debug": "infisical run -- sam local invoke --debug-port 5858 HorariuApiFunction -e events/event-get-course.json",
+    "sam:invoke:updateCourse:debug": "infisical run -- sam local invoke --debug-port 5858 HorariuApiFunction -e events/event-update-course.json",
+    "sam:invoke:deleteCourse:debug": "infisical run -- sam local invoke --debug-port 5858 HorariuApiFunction -e events/event-delete-course.json"
   },
   "keywords": [],
   "author": "",

--- a/backend/samconfig.toml
+++ b/backend/samconfig.toml
@@ -1,8 +1,0 @@
-version = 0.1
-[default.deploy.parameters]
-stack_name = "horariu-app"
-s3_bucket = "horariu-app-deployment-bucket"
-region = "us-east-1"
-confirm_changeset = true
-capabilities = "CAPABILITY_IAM"
-image_repositories = []

--- a/backend/src/controllers/courseController.ts
+++ b/backend/src/controllers/courseController.ts
@@ -1,4 +1,5 @@
 import { CourseService } from '../services/CourseService'
+import { validateCourse, validateUpdateCourse, validateCourseParams } from '../schemas/course.schema'
 
 export class CourseController {
   registerCourse = async (userId: string, course: unknown) => {
@@ -7,7 +8,12 @@ export class CourseController {
         throw new Error('[UNAUTHORIZED]: User not found')
       }
 
-      const newCourse = await CourseService.registerCourse(userId, course)
+      const courseValid = await validateCourse(course)
+      if (!courseValid.success) {
+        throw new Error('Validation failed')
+      }
+
+      const newCourse = await CourseService.registerCourse(userId, courseValid.data)
       return {
         statusCode: 201,
         body: JSON.stringify({ message: 'Courses registered successfully', newCourse })
@@ -42,13 +48,18 @@ export class CourseController {
 
   getCourse = async (userId: string, params: unknown) => {
     try {
+      const paramsValid = await validateCourseParams(params)
+      if (!paramsValid.success) {
+        throw new Error('Validation failed')
+      }
+
       if (!userId) {
         throw new Error('[UNAUTHORIZED]: User not found')
       }
-      const course = await CourseService.getCourse(userId, params)
+      const course = await CourseService.getCourse(userId, paramsValid.data)
       return {
         statusCode: 201,
-        body: JSON.stringify({ message: 'Courses retrieved successfully', course })
+        body: JSON.stringify({ message: 'Course retrieved successfully', course })
       }
     } catch (error) {
       console.error('[getCourse]:', (error as Error).message)
@@ -59,12 +70,23 @@ export class CourseController {
     }
   }
 
-  updateCourse = async (userId: string, params: unknown, body: unknown) => {
+  updateCourse = async (userId: string, params: unknown, updates: unknown) => {
     try {
       if (!userId) {
         throw new Error('[UNAUTHORIZED]: User not found')
       }
-      const updatedCourse = await CourseService.updateCourse(userId, params, body)
+
+      const paramsValid = await validateCourseParams(params)
+      if (!paramsValid.success) {
+        throw new Error('Validation failed')
+      }
+
+      const updateValid = await validateUpdateCourse(updates)
+      if (!updateValid.success) {
+        throw new Error('Validation failed')
+      }
+
+      const updatedCourse = await CourseService.updateCourse(userId, paramsValid.data, updateValid.data)
       return {
         statusCode: 201,
         body: JSON.stringify({ message: 'Course updated successfully', updatedCourse })
@@ -83,7 +105,13 @@ export class CourseController {
       if (!userId) {
         throw new Error('[UNAUTHORIZED]: User not found')
       }
-      const deletedCourse = await CourseService.deleteCourse(userId, params)
+
+      const paramsValid = await validateCourseParams(params)
+      if (!paramsValid.success) {
+        throw new Error('Validation failed')
+      }
+
+      const deletedCourse = await CourseService.deleteCourse(userId, paramsValid.data)
       return {
         statusCode: 201,
         body: JSON.stringify({ message: 'Course deleted successfully', deletedCourse })

--- a/backend/src/controllers/courseController.ts
+++ b/backend/src/controllers/courseController.ts
@@ -2,8 +2,8 @@ import { CourseService } from '../services/CourseService'
 import { validateCourse, validateUpdateCourse, validateCourseParams } from '../schemas/course.schema'
 import { validateCourses } from '../schemas/schedule.schema'
 
-export class CourseController {
-  generateSchedules = async (courses: unknown) => {
+export const CourseController = {
+  async generateSchedules (courses: unknown) {
     try {
       const validatedCourses = await validateCourses(courses)
       if (!validatedCourses.success) {
@@ -22,9 +22,9 @@ export class CourseController {
         body: JSON.stringify({ message: 'Internal server error' })
       }
     }
-  }
+  },
 
-  registerCourse = async (userId: string, course: unknown) => {
+  async registerCourse (userId: string, course: unknown) {
     try {
       if (!userId) {
         throw new Error('[UNAUTHORIZED]: User not found')
@@ -47,9 +47,9 @@ export class CourseController {
         body: JSON.stringify({ message: 'Internal server error' })
       }
     }
-  }
+  },
 
-  getCourses = async (userId: string) => {
+  async getCourses (userId: string) {
     try {
       if (!userId) {
         throw new Error('[UNAUTHORIZED]: User not found')
@@ -66,9 +66,9 @@ export class CourseController {
         body: JSON.stringify({ message: 'Internal server error' })
       }
     }
-  }
+  },
 
-  getCourse = async (userId: string, params: unknown) => {
+  async getCourse (userId: string, params: unknown) {
     try {
       const paramsValid = await validateCourseParams(params)
       if (!paramsValid.success) {
@@ -90,9 +90,9 @@ export class CourseController {
         body: JSON.stringify({ message: 'Internal server error' })
       }
     }
-  }
+  },
 
-  updateCourse = async (userId: string, params: unknown, updates: unknown) => {
+  async updateCourse (userId: string, params: unknown, updates: unknown) {
     try {
       if (!userId) {
         throw new Error('[UNAUTHORIZED]: User not found')
@@ -120,9 +120,9 @@ export class CourseController {
         body: JSON.stringify({ message: 'Internal server error' })
       }
     }
-  }
+  },
 
-  deleteCourse = async (userId: string, params: unknown) => {
+  async deleteCourse (userId: string, params: unknown) {
     try {
       if (!userId) {
         throw new Error('[UNAUTHORIZED]: User not found')

--- a/backend/src/controllers/courseController.ts
+++ b/backend/src/controllers/courseController.ts
@@ -1,7 +1,29 @@
 import { CourseService } from '../services/CourseService'
 import { validateCourse, validateUpdateCourse, validateCourseParams } from '../schemas/course.schema'
+import { validateCourses } from '../schemas/schedule.schema'
 
 export class CourseController {
+  generateSchedules = async (courses: unknown) => {
+    try {
+      const validatedCourses = await validateCourses(courses)
+      if (!validatedCourses.success) {
+        throw new Error(JSON.stringify(validatedCourses.error.errors))
+      }
+
+      const schedules = await CourseService.generateSchedules(validatedCourses.data)
+      return {
+        statusCode: 201,
+        body: JSON.stringify({ message: 'Schedules generated successfully', schedules })
+      }
+    } catch (error) {
+      console.error('[generateSchedule]:', (error as Error).message)
+      return {
+        statusCode: 500,
+        body: JSON.stringify({ message: 'Internal server error' })
+      }
+    }
+  }
+
   registerCourse = async (userId: string, course: unknown) => {
     try {
       if (!userId) {

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -1,10 +1,16 @@
 import { UserService } from '../services/UserService'
-import { UserCredentials } from '../schemas/user.schema'
+import { validateUser, validateLogin } from '../schemas/user.schema'
 
 export class UserController {
-  register = async (user: UserCredentials) => {
+  register = async (user: unknown) => {
     try {
-      const { token } = await UserService.register(user)
+      const validatedUser = await validateUser(user)
+
+      if (!validatedUser.success) {
+        throw new Error(JSON.stringify(validatedUser.error.format()))
+      }
+
+      const { token } = await UserService.register(validatedUser.data)
 
       return {
         statusCode: 201,
@@ -19,9 +25,14 @@ export class UserController {
     }
   }
 
-  login = async (user: UserCredentials) => {
+  login = async (user: unknown) => {
     try {
-      const { token } = await UserService.login(user)
+      const validatedUser = await validateLogin(user)
+
+      if (!validatedUser.success) {
+        throw new Error(JSON.stringify(validatedUser.error.format()))
+      }
+      const { token } = await UserService.login(validatedUser.data)
       return {
         statusCode: 201,
         body: JSON.stringify({ message: 'Login successful', token })

--- a/backend/src/controllers/userController.ts
+++ b/backend/src/controllers/userController.ts
@@ -1,8 +1,8 @@
 import { UserService } from '../services/UserService'
 import { validateUser, validateLogin } from '../schemas/user.schema'
 
-export class UserController {
-  register = async (user: unknown) => {
+export const UserController = {
+  async register (user: unknown) {
     try {
       const validatedUser = await validateUser(user)
 
@@ -23,9 +23,9 @@ export class UserController {
         body: JSON.stringify({ message: 'Internal server error' })
       }
     }
-  }
+  },
 
-  login = async (user: unknown) => {
+  async login (user: unknown) {
     try {
       const validatedUser = await validateLogin(user)
 

--- a/backend/src/middlewares/auth.ts
+++ b/backend/src/middlewares/auth.ts
@@ -1,3 +1,4 @@
+import { APIGatewayTokenAuthorizerEvent, APIGatewayAuthorizerResult } from 'aws-lambda'
 import jwt from 'jsonwebtoken'
 
 export interface AuthenticatedUser {
@@ -5,11 +6,7 @@ export interface AuthenticatedUser {
   email: string;
 }
 
-const checkAuthHeader = (authHeader: string | undefined): string => {
-  if (!authHeader) {
-    throw new Error('[UNAUTHORIZED]: No token provided')
-  }
-
+const checkAuthHeader = (authHeader: string): string => {
   const token = authHeader.split(' ')[1]
   if (!token) {
     throw new Error('[UNAUTHORIZED]: Invalid token format')
@@ -17,7 +14,7 @@ const checkAuthHeader = (authHeader: string | undefined): string => {
   return token
 }
 
-export const verifyToken = (authHeader: string | undefined): AuthenticatedUser => {
+export const verifyToken = (authHeader: string): AuthenticatedUser => {
   const token = checkAuthHeader(authHeader)
 
   try {
@@ -31,5 +28,36 @@ export const verifyToken = (authHeader: string | undefined): AuthenticatedUser =
     } else {
       throw new Error('Internal server error')
     }
+  }
+}
+
+/* eslint-disable @typescript-eslint/naming-convention */
+const generatePolicy = (principalId: string, effect: 'Allow' | 'Deny', resource: string): APIGatewayAuthorizerResult => {
+  return {
+    principalId,
+    policyDocument: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Action: 'execute-api:Invoke',
+          Effect: effect,
+          Resource: resource
+        }
+      ]
+    }
+  }
+}
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export const handler = async (event: APIGatewayTokenAuthorizerEvent): Promise<APIGatewayAuthorizerResult> => {
+  try {
+    if (!event.authorizationToken) {
+      throw new Error('[UNAUTHORIZED]: No authorization token provided')
+    }
+    const user = verifyToken(event.authorizationToken)
+    return generatePolicy(user.userId, 'Allow', event.methodArn)
+  } catch (error) {
+    console.error('Authorization failed:', error instanceof Error ? error.message : String(error))
+    return generatePolicy('Unauthorized', 'Deny', event.methodArn)
   }
 }

--- a/backend/src/repositories/userRepository.ts
+++ b/backend/src/repositories/userRepository.ts
@@ -2,14 +2,10 @@ import { db } from '../database/database'
 import { users } from '../database/schema/users'
 import { eq, count } from 'drizzle-orm'
 import bcrypt from 'bcrypt'
-
-interface IUserCredentials {
-  email: string,
-  password: string
-}
+import { UserCredentials } from '../schemas/user.schema'
 
 export const UserRepository = {
-  async createUser ({ email, password }: IUserCredentials): Promise<{ id: string; email: string }> {
+  async createUser ({ email, password }: UserCredentials): Promise<{ id: string; email: string }> {
     const hashedPass = await bcrypt.hash(password, 10)
     const userCreated = await db.insert(users).values({ email, password: hashedPass }).returning()
     return { id: userCreated[0].id, email: userCreated[0].email }
@@ -23,7 +19,7 @@ export const UserRepository = {
     return result[0].value > 0
   },
 
-  async verifyCredentials ({ email, password }: IUserCredentials): Promise<{ id: string; email: string } | null> {
+  async verifyCredentials ({ email, password }: UserCredentials): Promise<{ id: string; email: string } | null> {
     const userCredentials = await db
       .select({ id: users.id, email: users.email, password: users.password })
       .from(users)

--- a/backend/src/schemas/course.schema.ts
+++ b/backend/src/schemas/course.schema.ts
@@ -41,6 +41,8 @@ export const courseSchema = z.object({
   courseDetails: courseDetailsSchema.optional()
 })
 
+export type CourseInfo = z.infer<typeof courseSchema>
+
 export const courseParamsSchema = z.object({
   courseName: z.string().min(1, 'Course name cannot be empty'),
   day: z.enum(['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo']),
@@ -54,7 +56,11 @@ export const courseParamsSchema = z.object({
   )
 })
 
+export type CourseParamsInfo = z.infer<typeof courseParamsSchema>
+
 export const updateCourseSchema = courseSchema.partial()
+
+export type CourseUpdateInfo = z.infer<typeof updateCourseSchema>
 
 export async function validateCourse (course: unknown) {
   return courseSchema.safeParseAsync(course)

--- a/backend/src/schemas/course.schema.ts
+++ b/backend/src/schemas/course.schema.ts
@@ -12,9 +12,8 @@ export const courseSchema = z.object({
     invalid_type_error: 'Course name must be a string',
     required_error: 'Course name is required'
   }).min(1, 'Course name cannot be empty').max(255, 'Course name cannot exceed 255 characters'),
-  // TODO: Change to en
-  day: z.enum(['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo'], {
-    invalid_type_error: 'Day must be one of: Lunes, Martes, Miércoles, Jueves, Viernes, Sábado, Domingo',
+  day: z.enum(['L', 'K', 'M', 'J', 'V', 'S', 'D'], {
+    invalid_type_error: 'Day must be one of: L, K, M, J, V, S, D',
     required_error: 'Day is required'
   }),
 
@@ -41,11 +40,9 @@ export const courseSchema = z.object({
   courseDetails: courseDetailsSchema.optional()
 })
 
-export type CourseInfo = z.infer<typeof courseSchema>
-
 export const courseParamsSchema = z.object({
   courseName: z.string().min(1, 'Course name cannot be empty'),
-  day: z.enum(['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo']),
+  day: z.enum(['L', 'K', 'M', 'J', 'V', 'S', 'D']),
   startTime: z.string().regex(
     /^([0-1][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])$/,
     'Start time must be in the format HH:mm:ss'
@@ -56,9 +53,11 @@ export const courseParamsSchema = z.object({
   )
 })
 
-export type CourseParamsInfo = z.infer<typeof courseParamsSchema>
-
 export const updateCourseSchema = courseSchema.partial()
+
+export type CourseInfo = z.infer<typeof courseSchema>
+
+export type CourseParamsInfo = z.infer<typeof courseParamsSchema>
 
 export type CourseUpdateInfo = z.infer<typeof updateCourseSchema>
 

--- a/backend/src/schemas/schedule.schema.ts
+++ b/backend/src/schemas/schedule.schema.ts
@@ -5,17 +5,22 @@ export const timeSlotSchema = z.object({
   end: z.string().regex(/^([0-1][0-9]|2[0-3]):([0-5][0-9])$/, 'End time must be in HH:mm format')
 })
 
-const scheduleSchema = z.record(
-  z.string().length(1),
-  timeSlotSchema
-)
+export const scheduleSchema = z
+  .object({})
+  .catchall(timeSlotSchema)
+  .refine(schedule => Object.keys(schedule).length > 0, {
+    message: 'At least one schedule entry is required'
+  })
+  .refine(schedule => Object.keys(schedule).every(day => ['L', 'K', 'M', 'J', 'V', 'S', 'D'].includes(day)), {
+    message: 'Invalid day key found. Allowed values: L, K, M, J, V, S, D'
+  })
 
-const groupSchema = z.object({
+export const groupSchema = z.object({
   name: z.string().min(1, 'Group name cannot be empty'),
   schedule: scheduleSchema
 })
 
-const courseSchema = z.object({
+export const courseSchema = z.object({
   name: z.string().min(1, 'Course name cannot be empty'),
   color: z.string().min(1, 'Color cannot be empty'),
   groups: z.array(groupSchema).min(1, 'Each course must have at least one group')

--- a/backend/src/schemas/schedule.schema.ts
+++ b/backend/src/schemas/schedule.schema.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod'
+
+export const timeSlotSchema = z.object({
+  start: z.string().regex(/^([0-1][0-9]|2[0-3]):([0-5][0-9])$/, 'Start time must be in HH:mm format'),
+  end: z.string().regex(/^([0-1][0-9]|2[0-3]):([0-5][0-9])$/, 'End time must be in HH:mm format')
+})
+
+const scheduleSchema = z.record(
+  z.string().length(1),
+  timeSlotSchema
+)
+
+const groupSchema = z.object({
+  name: z.string().min(1, 'Group name cannot be empty'),
+  schedule: scheduleSchema
+})
+
+const courseSchema = z.object({
+  name: z.string().min(1, 'Course name cannot be empty'),
+  color: z.string().min(1, 'Color cannot be empty'),
+  groups: z.array(groupSchema).min(1, 'Each course must have at least one group')
+})
+
+export const generateScheduleSchema = z.array(courseSchema).min(1, 'Must provide at least one course')
+
+const courseAndGroupSchema = z.object({
+  courseName: z.string().min(1, 'Course name cannot be empty'),
+  color: z.string().min(1, 'Color cannot be empty'),
+  group: groupSchema
+})
+
+export const currentScheduleSchema = z.array(courseAndGroupSchema)
+
+export const allCoursesSchema = z.array(
+  z.object({
+    courseName: z.string().min(1, 'Course name cannot be empty'),
+    color: z.string().min(1, 'Color cannot be empty'),
+    group: groupSchema
+  })
+)
+
+export async function validateCourses (courses: unknown) {
+  return generateScheduleSchema.safeParseAsync(courses)
+}
+
+export type TimeSlot = z.infer<typeof timeSlotSchema>
+
+export type Group = z.infer<typeof groupSchema>
+
+export type GenerateScheduleInfo = z.infer<typeof generateScheduleSchema>
+
+export type CurrentSchedule = z.infer<typeof currentScheduleSchema>
+
+export type AllCourses = z.infer<typeof allCoursesSchema>

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -2,20 +2,34 @@ import { APIGatewayProxyHandler, APIGatewayProxyResult, APIGatewayProxyEvent } f
 import { UserController } from './controllers/userController'
 import { CourseController } from './controllers/courseController'
 
-const getCorsHeaders = (origin: string, methods: string) => ({
-  /* eslint-disable @typescript-eslint/naming-convention */
-  'Access-Control-Allow-Origin': origin,
-  'Access-Control-Allow-Methods': methods,
-  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
-  'Access-Control-Allow-Credentials': 'true'
-  /* eslint-enable @typescript-eslint/naming-convention */
-})
+const allowedOrigins = ['http://localhost:5173', 'https://horariu-client.vercel.app']
+
+const getCorsHeaders = (origin: string | undefined, methods: string) => {
+  const allowedOrigin = origin && allowedOrigins.includes(origin) ? origin : ''
+
+  return {
+    /* eslint-disable @typescript-eslint/naming-convention */
+    'Access-Control-Allow-Origin': allowedOrigin,
+    'Access-Control-Allow-Methods': methods,
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Credentials': 'true'
+    /* eslint-enable @typescript-eslint/naming-convention */
+  }
+}
 
 export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   try {
     const { httpMethod, path, body } = event
 
-    const origin = event.headers?.origin ?? 'http://localhost:5173'
+    const origin = event.headers?.origin || event.headers?.Origin
+
+    if (!origin || !allowedOrigins.includes(origin)) {
+      return {
+        statusCode: 403,
+        headers: getCorsHeaders(origin, ''),
+        body: JSON.stringify({ error: 'CORS policy: This origin is not allowed' })
+      }
+    }
 
     if (httpMethod === 'OPTIONS') {
       return {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -3,9 +3,6 @@ import { UserController } from './controllers/userController'
 import { CourseController } from './controllers/courseController'
 import { verifyToken } from './middlewares/auth'
 
-const userController = new UserController()
-const courseController = new CourseController()
-
 export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
   try {
     const { httpMethod, path, body } = event
@@ -13,7 +10,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
     const parsedBody = typeof body === 'string' ? JSON.parse(body) : body
 
     if (httpMethod === 'POST' && path === '/register') {
-      const result = await userController.register(parsedBody)
+      const result = await UserController.register(parsedBody)
       return {
         statusCode: 201,
         body: result.body
@@ -21,7 +18,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
     }
 
     if (httpMethod === 'POST' && path === '/login') {
-      const result = await userController.login(parsedBody)
+      const result = await UserController.login(parsedBody)
       return {
         statusCode: 201,
         body: result.body
@@ -29,7 +26,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
     }
 
     if (httpMethod === 'POST' && path === '/courses/generate') {
-      const result = await courseController.generateSchedules(parsedBody)
+      const result = await CourseController.generateSchedules(parsedBody)
       return {
         statusCode: 200,
         body: result.body
@@ -38,7 +35,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
 
     if (httpMethod === 'POST' && path === '/courses') {
       const user = verifyToken(event.headers?.Authorization)
-      const result = await courseController.registerCourse(user.userId, parsedBody)
+      const result = await CourseController.registerCourse(user.userId, parsedBody)
       return {
         statusCode: 200,
         body: result.body
@@ -47,7 +44,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
 
     if (httpMethod === 'GET' && path === '/courses') {
       const user = verifyToken(event.headers?.Authorization)
-      const result = await courseController.getCourses(user.userId)
+      const result = await CourseController.getCourses(user.userId)
       return {
         statusCode: 200,
         body: result.body
@@ -63,7 +60,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
           body: 'Missing required path parameters'
         }
       }
-      const result = await courseController.getCourse(user.userId, pathParameters)
+      const result = await CourseController.getCourse(user.userId, pathParameters)
       return {
         statusCode: 200,
         body: result.body
@@ -79,7 +76,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
           body: JSON.stringify({ message: 'Missing required path parameters' })
         }
       }
-      const result = await courseController.updateCourse(user.userId, pathParameters, parsedBody)
+      const result = await CourseController.updateCourse(user.userId, pathParameters, parsedBody)
       return {
         statusCode: 200,
         body: result.body
@@ -95,7 +92,7 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
           body: 'Missing required path parameters'
         }
       }
-      const result = await courseController.deleteCourse(user.userId, pathParameters)
+      const result = await CourseController.deleteCourse(user.userId, pathParameters)
       return {
         statusCode: 200,
         body: result.body

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -28,6 +28,14 @@ export const handler: APIGatewayProxyHandler = async (event: APIGatewayProxyEven
       }
     }
 
+    if (httpMethod === 'POST' && path === '/courses/generate') {
+      const result = await courseController.generateSchedules(parsedBody)
+      return {
+        statusCode: 200,
+        body: result.body
+      }
+    }
+
     if (httpMethod === 'POST' && path === '/courses') {
       const user = verifyToken(event.headers?.Authorization)
       const result = await courseController.registerCourse(user.userId, parsedBody)

--- a/backend/src/services/CourseService.ts
+++ b/backend/src/services/CourseService.ts
@@ -1,14 +1,10 @@
-import { validateCourse, validateUpdateCourse, validateCourseParams } from '../schemas/course.schema'
 import { CourseRepository } from '../repositories/courseRepository'
+import { CourseInfo, CourseParamsInfo, CourseUpdateInfo } from '../schemas/course.schema'
 
 export const CourseService = {
-  async registerCourse (userId: string, data: unknown) {
-    const courseValid = await validateCourse(data)
-    if (!courseValid.success) {
-      throw new Error('Validation failed')
-    }
 
-    const newCourse = await CourseRepository.addCourse({ ...courseValid.data, userId })
+  async registerCourse (userId: string, course: CourseInfo) {
+    const newCourse = await CourseRepository.addCourse({ ...course, userId })
 
     if ('error' in newCourse) {
       throw new Error(newCourse.error as string)
@@ -23,13 +19,8 @@ export const CourseService = {
     return courses && courses.length > 0 ? courses : []
   },
 
-  async getCourse (userId: string, params: unknown) {
-    const paramsValid = await validateCourseParams(params)
-    if (!paramsValid.success) {
-      throw new Error('Validation failed')
-    }
-
-    const course = await CourseRepository.getCourse({ userId, ...paramsValid.data })
+  async getCourse (userId: string, params: CourseParamsInfo) {
+    const course = await CourseRepository.getCourse({ userId, ...params })
     if (!course) {
       throw new Error('Course not found')
     }
@@ -37,18 +28,8 @@ export const CourseService = {
     return course
   },
 
-  async updateCourse (userId: string, params: unknown, updates: unknown) {
-    const paramsValid = await validateCourseParams(params)
-    if (!paramsValid.success) {
-      throw new Error('Validation failed')
-    }
-
-    const updateValid = await validateUpdateCourse(updates)
-    if (!updateValid.success) {
-      throw new Error('Validation failed')
-    }
-
-    const updatedCourse = await CourseRepository.updateCourse({ userId, ...paramsValid.data }, updateValid.data)
+  async updateCourse (userId: string, params: CourseParamsInfo, updates: CourseUpdateInfo) {
+    const updatedCourse = await CourseRepository.updateCourse({ userId, ...params }, updates)
     if (!updatedCourse) {
       throw new Error('Course not found')
     }
@@ -56,17 +37,12 @@ export const CourseService = {
     return updatedCourse
   },
 
-  async deleteCourse (userId: string, params: unknown) {
-    const paramsValid = await validateCourseParams(params)
-    if (!paramsValid.success) {
-      throw new Error('Validation failed')
-    }
-
-    const deletedCourse = await CourseRepository.deleteCourse({ userId, ...paramsValid.data })
+  async deleteCourse (userId: string, params: CourseParamsInfo) {
+    const deletedCourse = await CourseRepository.deleteCourse({ userId, ...params })
     if (!deletedCourse) {
       throw new Error('Course not found or already deleted')
     }
 
-    return paramsValid.data
+    return params
   }
 }

--- a/backend/src/services/CourseService.ts
+++ b/backend/src/services/CourseService.ts
@@ -1,7 +1,14 @@
 import { CourseRepository } from '../repositories/courseRepository'
 import { CourseInfo, CourseParamsInfo, CourseUpdateInfo } from '../schemas/course.schema'
+import { GenerateScheduleInfo } from '../schemas/schedule.schema'
+import { generateAllSchedules } from '../utils/scheduleUtils'
 
 export const CourseService = {
+
+  async generateSchedules (courses: GenerateScheduleInfo) {
+    const generatedSchedules = generateAllSchedules(courses)
+    return generatedSchedules
+  },
 
   async registerCourse (userId: string, course: CourseInfo) {
     const newCourse = await CourseRepository.addCourse({ ...course, userId })

--- a/backend/src/services/UserService.ts
+++ b/backend/src/services/UserService.ts
@@ -1,43 +1,28 @@
-import { validateUser, validateLogin } from '../schemas/user.schema'
+import { UserCredentials } from '../schemas/user.schema'
 import { signToken } from '../utils/utils'
 import { UserRepository } from '../repositories/userRepository'
 
-interface IUserService {
-  register(data: unknown): Promise<{ token: string }>;
-  login(data: unknown): Promise<{ token: string }>;
-}
-
-export const UserService: IUserService = {
-  async register (data: unknown): Promise<{ token: string }> {
-    const result = await validateUser(data)
-    if (!result.success) {
-      throw new Error(JSON.stringify(result.error.format()))
-    }
-
-    const emailExists = await UserRepository.emailExists(result.data.email)
+export const UserService = {
+  async register (user: UserCredentials): Promise<{ token: string }> {
+    const emailExists = await UserRepository.emailExists(user.email)
     if (emailExists) {
       throw new Error('Email already exists')
     }
 
-    const newUser = await UserRepository.createUser(result.data)
+    const newUser = await UserRepository.createUser(user)
 
     const token = signToken(newUser)
 
     return { token }
   },
 
-  async login (data: unknown): Promise<{ token: string }> {
-    const result = await validateLogin(data)
-    if (!result.success) {
-      throw new Error(JSON.stringify(result.error.format()))
-    }
-
-    const user = await UserRepository.verifyCredentials(result.data)
-    if (!user) {
+  async login (user: UserCredentials): Promise<{ token: string }> {
+    const verifiedUser = await UserRepository.verifyCredentials(user)
+    if (!verifiedUser) {
       throw new Error('Invalid credentials')
     }
 
-    const token = signToken(user)
+    const token = signToken(verifiedUser)
 
     return { token }
   }

--- a/backend/src/utils/scheduleUtils.ts
+++ b/backend/src/utils/scheduleUtils.ts
@@ -1,0 +1,61 @@
+import type { GenerateScheduleInfo, TimeSlot, CurrentSchedule, Group, AllCourses } from '../schemas/schedule.schema'
+
+function timeToMinutes (timeStr: string): number {
+  const [hours, minutes] = timeStr.split(':').map(Number)
+  return hours * 60 + minutes
+}
+
+function hasTimeConflict (slot1: TimeSlot, slot2: TimeSlot): boolean {
+  const start1 = timeToMinutes(slot1.start)
+  const end1 = timeToMinutes(slot1.end)
+  const start2 = timeToMinutes(slot2.start)
+  const end2 = timeToMinutes(slot2.end)
+
+  return (start1 < end2 && start2 < end1)
+}
+
+function hasConflict (currentSchedule: CurrentSchedule, group: Group): boolean {
+  for (const day in group.schedule) {
+    const newTimeSlot = group.schedule[day]
+
+    for (const selectedGroup of currentSchedule) {
+      const existingGroup = selectedGroup.group
+      if (existingGroup.schedule[day]) {
+        const existingTimeSlot = existingGroup.schedule[day]
+        if (hasTimeConflict(newTimeSlot, existingTimeSlot)) {
+          return true
+        }
+      }
+    }
+  }
+  return false
+}
+
+export function generateAllSchedules (courses: GenerateScheduleInfo): AllCourses[] {
+  const allSchedules: AllCourses[] = []
+
+  function backtrack (currentSchedule: CurrentSchedule, courseIndex: number) {
+    if (courseIndex >= courses.length) {
+      allSchedules.push([...currentSchedule])
+      return
+    }
+
+    const currentCourse = courses[courseIndex]
+    for (const group of currentCourse.groups) {
+      if (!hasConflict(currentSchedule, group)) {
+        currentSchedule.push({
+          courseName: currentCourse.name,
+          color: currentCourse.color,
+          group
+        })
+
+        backtrack(currentSchedule, courseIndex + 1)
+
+        currentSchedule.pop()
+      }
+    }
+  }
+
+  backtrack([], 0)
+  return allSchedules
+}

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -25,6 +25,18 @@ Parameters:
 
 
 Resources:
+  TokenAuthorizer:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: dist/middlewares/auth.handler
+      Runtime: nodejs18.x
+      Policies:
+        - AWSLambdaBasicExecutionRole
+      Environment:
+        Variables:
+          JWT_SECRET: !Ref JwtSecret
+
+
   HorariuApi:
       Type: AWS::Serverless::Api
       Properties:
@@ -34,6 +46,15 @@ Resources:
           AllowMethods: "'OPTIONS,GET,POST,PATCH,DELETE'"
           AllowHeaders: "'Content-Type,Authorization'"
           AllowOrigin: "'http://localhost:5173'"
+        Auth:
+          Authorizers:
+            TokenAuthorizer:
+              FunctionArn: !GetAtt TokenAuthorizer.Arn
+              Identity:
+                Headers:
+                  - Authorization
+              AuthorizerPayloadFormatVersion: 2.0
+              EnableSimpleResponses: true
     
   HorariuApiFunction:
     Type: AWS::Serverless::Function
@@ -84,27 +105,37 @@ Resources:
             RestApiId: !Ref HorariuApi
             Path: /courses
             Method: POST
+            Auth:
+              Authorizer: TokenAuthorizer
         GetCourses:
           Type: Api
           Properties:
             RestApiId: !Ref HorariuApi
             Path: /courses
             Method: GET
+            Auth:
+              Authorizer: TokenAuthorizer
         GetCourse:
           Type: Api
           Properties:
             RestApiId: !Ref HorariuApi
             Path: /courses/{courseName}/{day}/{startTime}/{groupNumber}
             Method: GET
+            Auth:
+              Authorizer: TokenAuthorizer
         UpdateCourse:
           Type: Api
           Properties:
             RestApiId: !Ref HorariuApi
             Path: /courses/{courseName}/{day}/{startTime}/{groupNumber}
             Method: PATCH
+            Auth:
+              Authorizer: TokenAuthorizer
         DeleteCourse:
           Type: Api
           Properties:
             RestApiId: !Ref HorariuApi
             Path: /courses/{courseName}/{day}/{startTime}/{groupNumber}
             Method: DELETE
+            Auth:
+              Authorizer: TokenAuthorizer

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -29,6 +29,11 @@ Resources:
       Type: AWS::Serverless::Api
       Properties:
         StageName: !Ref StageName
+        Cors:
+          AllowCredentials: true
+          AllowMethods: "'OPTIONS,GET,POST,PATCH,DELETE'"
+          AllowHeaders: "'Content-Type,Authorization'"
+          AllowOrigin: "'http://localhost:5173'"
     
   HorariuApiFunction:
     Type: AWS::Serverless::Function
@@ -67,6 +72,12 @@ Resources:
             RestApiId: !Ref HorariuApi
             Path: /login
             Method: POST
+        GenerateSchedules:
+          Type: Api
+          Properties:
+            RestApiId: !Ref HorariuApi
+            Path: /courses/generate
+            Method: POST
         CreateCourse:
           Type: Api
           Properties:
@@ -85,9 +96,15 @@ Resources:
             RestApiId: !Ref HorariuApi
             Path: /courses/{courseName}/{day}/{startTime}/{groupNumber}
             Method: GET
-        GenerateSchedules:
+        UpdateCourse:
           Type: Api
           Properties:
             RestApiId: !Ref HorariuApi
-            Path: /courses/generate
-            Method: POST
+            Path: /courses/{courseName}/{day}/{startTime}/{groupNumber}
+            Method: PATCH
+        DeleteCourse:
+          Type: Api
+          Properties:
+            RestApiId: !Ref HorariuApi
+            Path: /courses/{courseName}/{day}/{startTime}/{groupNumber}
+            Method: DELETE

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -5,6 +5,9 @@ Transform:
 - AWS::Serverless-2016-10-31
 
 Parameters:
+  StageName:
+    Type: String
+    Default: Dev
   DBHost:
     Type: String
   DBUser:
@@ -22,6 +25,11 @@ Parameters:
 
 
 Resources:
+  HorariuApi:
+      Type: AWS::Serverless::Api
+      Properties:
+        StageName: !Ref StageName
+    
   HorariuApiFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -50,25 +58,36 @@ Resources:
         RegisterUser:
           Type: Api
           Properties:
+            RestApiId: !Ref HorariuApi
             Path: /register
             Method: POST
         LoginUser:
           Type: Api
           Properties:
+            RestApiId: !Ref HorariuApi
             Path: /login
             Method: POST
         CreateCourse:
           Type: Api
           Properties:
+            RestApiId: !Ref HorariuApi
             Path: /courses
             Method: POST
         GetCourses:
           Type: Api
           Properties:
+            RestApiId: !Ref HorariuApi
             Path: /courses
             Method: GET
         GetCourse:
           Type: Api
           Properties:
+            RestApiId: !Ref HorariuApi
             Path: /courses/{courseName}/{day}/{startTime}/{groupNumber}
             Method: GET
+        GenerateSchedules:
+          Type: Api
+          Properties:
+            RestApiId: !Ref HorariuApi
+            Path: /courses/generate
+            Method: POST

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -45,7 +45,7 @@ Resources:
           AllowCredentials: true
           AllowMethods: "'OPTIONS,GET,POST,PATCH,DELETE'"
           AllowHeaders: "'Content-Type,Authorization'"
-          AllowOrigin: "'http://localhost:5173'"
+          AllowOrigin: "'https://horariu-client.vercel.app'"
         Auth:
           Authorizers:
             TokenAuthorizer:


### PR DESCRIPTION
# Description
The functionality to generate all the possible schedules based on the added courses.
Also implemented an API Authorizer for endpoints that need a token, this way if there's a request to an endpoint that requires a token and it doesn't have a token, then the main lambda function does not get called

## Changes made
- Creation of an endpoint to generate schedules
- Implemented an API Authorizer
- Change the validation responsibility to the controller
- Add a deployment step to AWS after checking the build, lint and tests.

## Screenshots
- Endpoint to generate schedules:
![image](https://github.com/user-attachments/assets/303821ce-f33a-4fcd-9670-5abd56920e15)

- Authorizer
![image](https://github.com/user-attachments/assets/2dbaba06-2ab3-4f7f-8a1e-dca798a83432)

## Next steps
- Handle errors on the API
- Test cases for the API