### PR TITLE
fix: Update deploy script working directory in deploy-api workflow

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -110,8 +110,10 @@ jobs:
           pip install aws-sam-cli
 
       - name: Make deploy script executable
-        run: chmod +x backend/deploy.sh
+        run: chmod +x deploy.sh
+        working-directory: backend
 
       - name: Run Deploy Script (Prod)
-        run: backend/deploy.sh Prod
+        run: deploy.sh Prod
+        working-directory: backend
 


### PR DESCRIPTION
Updated the API deployment job to work inside the backend directory.

It failed because the script `./deploy.sh` executed `npm run build` outside the backend directory.

![image](https://github.com/user-attachments/assets/a842b05c-2142-4a1b-841d-3a7d48b42fb5)
